### PR TITLE
Struct migration

### DIFF
--- a/examples/component_migration.rs
+++ b/examples/component_migration.rs
@@ -1,0 +1,76 @@
+use bevy::prelude::*;
+use bevy_simple_subsecond_system::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(SimpleSubsecondPlugin::default())
+        .add_systems(Startup, |mut commands: Commands| {
+            commands.spawn((
+                Example {
+                    field_a: 5,
+                    ..Default::default()
+                },
+                Example2 {
+                    field_b: 1005,
+                    ..Default::default()
+                },
+            ));
+            commands.spawn((
+                Example {
+                    field_a: 8,
+                    ..Default::default()
+                },
+                Example2 {
+                    field_b: 1008,
+                    ..Default::default()
+                },
+            ));
+        })
+        .add_systems(Startup, register_components)
+        .add_systems(Update, print_components)
+        .insert_resource(PrintTimer(Timer::from_seconds(1.0, TimerMode::Repeating)))
+        .run();
+}
+
+#[derive(Resource)]
+struct PrintTimer(Timer);
+
+// This is #[hot] because new versions of hot patched components need
+// to be registered so their reflected type data are available
+#[hot(rerun_on_hot_patch = true)]
+fn register_components(registry: Res<AppTypeRegistry>) {
+    let mut registry = registry.write();
+    registry.register::<Example>();
+    registry.register::<Example2>();
+}
+
+// Try changing the components below:
+// - Rename them
+// - Add a field
+// - Remove a field
+
+#[derive(Debug, Reflect, Component, Default, HotPatchMigrate)]
+#[reflect(Component, Default, HotPatchMigrate)]
+struct Example {
+    field_a: usize,
+}
+
+#[derive(Debug, Reflect, Component, Default, HotPatchMigrate)]
+#[reflect(Component, Default, HotPatchMigrate)]
+struct Example2 {
+    field_b: usize,
+}
+
+#[hot]
+fn print_components(
+    time: Res<Time>,
+    mut timer: ResMut<PrintTimer>,
+    q: Query<(&Example, &Example2)>,
+) {
+    if timer.0.tick(time.delta()).just_finished() {
+        for v in q {
+            info!("{v:?}");
+        }
+    }
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,7 +1,8 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    FnArg, Ident, ItemFn, LitBool, Pat, PatIdent, ReturnType, Token, Type, TypePath, TypeReference,
+    DeriveInput, FnArg, Ident, ItemFn, LitBool, Pat, PatIdent, ReturnType, Token, Type, TypePath,
+    TypeReference,
     parse::{Parse, ParseStream},
     parse_macro_input,
 };
@@ -286,4 +287,20 @@ fn is_result_unit(output: &ReturnType) -> bool {
             _ => false,
         },
     }
+}
+
+#[proc_macro_derive(HotPatchMigrate)]
+pub fn derive_hot_patch_migrate(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    let expanded = quote! {
+        impl bevy_simple_subsecond_system::migration::HotPatchMigrate for #name {
+            fn current_type_id() -> std::any::TypeId {
+                bevy_simple_subsecond_system::dioxus_devtools::subsecond::HotFn::current(|| std::any::TypeId::of::<Self>()).call(())
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
 }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -1,0 +1,111 @@
+//! TODO
+
+use bevy::{
+    ecs::{
+        entity::Entity,
+        reflect::{AppTypeRegistry, ReflectComponent},
+        resource::Resource,
+        system::{Commands, Query, Res, ResMut, RunSystemOnce},
+        world::World,
+    },
+    platform::collections::HashMap,
+    prelude::{Deref, DerefMut},
+    reflect::{FromType, Reflect, prelude::ReflectDefault},
+};
+use std::{
+    any::{Any, TypeId},
+    sync::Arc,
+};
+
+/// TODO
+pub trait HotPatchMigrate: Any + Reflect + Default {
+    /// TODO
+    fn current_type_id() -> TypeId;
+}
+
+/// TODO
+#[derive(Clone)]
+pub struct ReflectHotPatchMigrate(pub Arc<dyn Fn() -> TypeId + Sync + Send + 'static>);
+
+impl<T: HotPatchMigrate> FromType<T> for ReflectHotPatchMigrate {
+    fn from_type() -> Self {
+        Self(Arc::new(T::current_type_id))
+    }
+}
+
+#[derive(Resource, Default, Deref, DerefMut)]
+pub(crate) struct ComponentMigrations(
+    HashMap<TypeId, Arc<dyn Fn() -> TypeId + Sync + Send + 'static>>,
+);
+
+pub(crate) fn migrate(world: &mut World) {
+    world
+        .run_system_cached(register_migratable_components)
+        .unwrap();
+
+    let migrations = world.resource::<ComponentMigrations>();
+    let changed: Vec<_> = migrations
+        .iter()
+        .filter(|(prev, current)| prev != &&current())
+        .map(|(prev, current)| (prev.clone(), current.clone()))
+        .collect();
+
+    for (prev, current) in &changed {
+        migrate_component(world, prev.clone(), current());
+    }
+
+    // Track hot patches to the new struct
+    let mut migrations = world.resource_mut::<ComponentMigrations>();
+    migrations.extend(changed.into_iter().map(|(_, current)| (current(), current)));
+}
+
+fn register_migratable_components(
+    mut migrations: ResMut<ComponentMigrations>,
+    registry: Res<AppTypeRegistry>,
+) {
+    for registration in registry.read().iter() {
+        let Some(current_type_id) = registration.data::<ReflectHotPatchMigrate>() else {
+            continue;
+        };
+
+        migrations
+            .entry(registration.type_id())
+            .or_insert_with(|| current_type_id.clone().0);
+    }
+}
+
+fn migrate_component(world: &mut World, from: TypeId, to: TypeId) {
+    world
+        .run_system_once(
+            move |es: Query<Entity>, world: &World, mut commands: Commands| {
+                for e in es {
+                    match world.get_reflect(e, from) {
+                        Ok(c) => {
+                            let c = c.reflect_clone().unwrap();
+                            commands.queue(move |world: &mut World| {
+                                world.resource_scope::<AppTypeRegistry, ()>(|world, registry| {
+                                    let registry = registry.read();
+                                    let reflect_default =
+                                        registry.get_type_data::<ReflectDefault>(to).unwrap();
+                                    let reflect_component =
+                                        registry.get_type_data::<ReflectComponent>(to).unwrap();
+
+                                    let entity = &mut world.entity_mut(e);
+
+                                    reflect_component.insert(
+                                        entity,
+                                        &*reflect_default.default(),
+                                        &registry,
+                                    );
+
+                                    reflect_component.apply(entity, &*c);
+                                });
+                            });
+                        }
+                        Err(_) => {}
+                    }
+                }
+            },
+        )
+        .unwrap();
+}


### PR DESCRIPTION
Hi, I saw that this it out of scope in the design doc, but I had already written it, so I figured I would a shoot you a PR anyway 😅

This PR implements simple struct migration when hot-patch happens that is able to handle struct renaming and field modifications. The same limitations apply as to function (struct needs to exist in the initial compilation).

User needs to derive `HotPatchMigrate` trait on a struct (and this struct must also implement `Component` and `Default`, and reflect all of these trait). Additionally, you need a `#[hot(rerun_on_hot_patch = true)]` that registers all the components. This can't be really removed until bevy implements some auto-registration solution.

The way this PR works is that it keeps a hashmap from `TypeId` to a hot function that returns `TypeId` for that type. When the struct is modified, the function start returning a different `TypeId` which can be detected and component from the previous `TypeId` can be migrated.

Note that docs are to do, it's completely unoptimized, and unwraps everywhere for now, because I wasn't sure if there's interest for this in the repo.