### PR TITLE
Use absolute paths and crate re-exports when referencing external crates in proc macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,11 @@ name = "bevy_simple_subsecond_system"
 version = "0.1.9"
 dependencies = [
  "bevy",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_ecs_macros",
+ "bevy_log",
+ "bevy_platform",
  "bevy_simple_subsecond_system_macros",
  "crossbeam-channel",
  "dioxus-devtools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,11 @@ readme = "readme.md"
 categories = ["game-development"]
 
 [dependencies]
-bevy = { version = "0.16.0", default-features = false, features = ["bevy_log"] }
+bevy_ecs = { version = "0.16.0" }
+bevy_log = { version = "0.16.0" }
+bevy_app = { version = "0.16.0" }
+bevy_platform = { version = "0.16.0" }
+bevy_ecs_macros = { version = "0.16.0" }
 dioxus-devtools = { version = "0.7.0-alpha.0" }
 bevy_simple_subsecond_system_macros = { path = "macros", version = "0.1.5" }
 crossbeam-channel = "0.5.15"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -110,13 +110,13 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let maybe_run_call = if rerun_on_hot_patch {
         quote! {
-            let name = ::bevy_simple_subsecond_system::_macros_internal::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
+            let name = ::bevy_simple_subsecond_system::__macros_internal::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
             ::bevy_simple_subsecond_system::__macros_internal::debug!("Hot-patched and rerunning system {name}");
             #hot_fn.call((world,))
         }
     } else {
         quote! {
-            let name = ::bevy_simple_subsecond_system::_macros_internal::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
+            let name = ::bevy_simple_subsecond_system::__macros_internal::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
             bevy::prelude::debug!("Hot-patched system {name}");
         }
     };

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -110,13 +110,13 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let maybe_run_call = if rerun_on_hot_patch {
         quote! {
-            let name = ::bevy_simple_subsecond_system::reexports::bevy_ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
-            ::bevy_simple_subsecond_system::reexports::bevy_log::debug!("Hot-patched and rerunning system {name}");
+            let name = ::bevy_simple_subsecond_system::_macros_internal::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
+            ::bevy_simple_subsecond_system::__macros_internal::debug!("Hot-patched and rerunning system {name}");
             #hot_fn.call((world,))
         }
     } else {
         quote! {
-            let name = ::bevy_simple_subsecond_system::reexports::bevy_ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
+            let name = ::bevy_simple_subsecond_system::_macros_internal::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
             bevy::prelude::debug!("Hot-patched system {name}");
         }
     };
@@ -133,13 +133,13 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let hotpatched_fn_definition = match has_single_world_param(sig) {
         WorldParam::Mut | WorldParam::Ref => quote! {
-            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy_simple_subsecond_system::reexports::bevy_ecs::world::World) #where_clause #original_output {
+            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy_simple_subsecond_system::__macros_internal::World) #where_clause #original_output {
                 #original_wrapper_fn #maybe_generics(world)
             }
         },
         WorldParam::None => quote! {
-            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy_simple_subsecond_system::reexports::bevy_ecs::world::World) #where_clause #original_output {
-                use ::bevy_simple_subsecond_system::reexports::bevy_ecs::system::SystemState;
+            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy_simple_subsecond_system::__macros_internal::World) #where_clause #original_output {
+                use ::bevy_simple_subsecond_system::__macros_internal::SystemState;
                 let mut __system_state: SystemState<(#(#param_types),*)> = SystemState::new(world);
                 let __unsafe_world = world.as_unsafe_world_cell_readonly();
 
@@ -170,13 +170,13 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         // Outer entry point: stable ABI, hot-reload safe
         #[cfg(all(not(target_family = "wasm"), debug_assertions))]
-        #vis fn #original_fn_name #impl_generics(world: &mut ::bevy_simple_subsecond_system::reexports::bevy_ecs::world::World) #where_clause #original_output {
+        #vis fn #original_fn_name #impl_generics(world: &mut ::bevy_simple_subsecond_system::__macros_internal::World) #where_clause #original_output {
             use std::any::Any as _;
             let type_id = #hotpatched_fn #maybe_generics.type_id();
             let contains_system = world.get_resource::<::bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap().0.contains_key(&type_id);
             if !contains_system {
                 let hot_fn_ptr = #hot_fn.ptr_address();
-                let system_ptr_update_id = world.register_system(move |world: &mut ::bevy_simple_subsecond_system::reexports::bevy_ecs::world::World| {
+                let system_ptr_update_id = world.register_system(move |world: &mut ::bevy_simple_subsecond_system::__macros_internal::World| {
                     let needs_update = {
                         let mut hot_patched_systems = world.get_resource_mut::<::bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap();
                         let mut hot_patched_system = hot_patched_systems.0.get_mut(&type_id).unwrap();

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -110,13 +110,13 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let maybe_run_call = if rerun_on_hot_patch {
         quote! {
-            let name = ::bevy::ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
-            ::bevy::prelude::debug!("Hot-patched and rerunning system {name}");
+            let name = ::bevy_simple_subsecond_system::reexports::bevy_ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
+            ::bevy_simple_subsecond_system::reexports::bevy_log::debug!("Hot-patched and rerunning system {name}");
             #hot_fn.call((world,))
         }
     } else {
         quote! {
-            let name = ::bevy::ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
+            let name = ::bevy_simple_subsecond_system::reexports::bevy_ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
             bevy::prelude::debug!("Hot-patched system {name}");
         }
     };
@@ -133,13 +133,13 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let hotpatched_fn_definition = match has_single_world_param(sig) {
         WorldParam::Mut | WorldParam::Ref => quote! {
-            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy::ecs::world::World) #where_clause #original_output {
+            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy_simple_subsecond_system::reexports::bevy_ecs::world::World) #where_clause #original_output {
                 #original_wrapper_fn #maybe_generics(world)
             }
         },
         WorldParam::None => quote! {
-            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy::ecs::world::World) #where_clause #original_output {
-                use ::bevy::ecs::system::SystemState;
+            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy_simple_subsecond_system::reexports::bevy_ecs::world::World) #where_clause #original_output {
+                use ::bevy_simple_subsecond_system::reexports::bevy_ecs::system::SystemState;
                 let mut __system_state: SystemState<(#(#param_types),*)> = SystemState::new(world);
                 let __unsafe_world = world.as_unsafe_world_cell_readonly();
 
@@ -170,13 +170,13 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         // Outer entry point: stable ABI, hot-reload safe
         #[cfg(all(not(target_family = "wasm"), debug_assertions))]
-        #vis fn #original_fn_name #impl_generics(world: &mut ::bevy::ecs::world::World) #where_clause #original_output {
+        #vis fn #original_fn_name #impl_generics(world: &mut ::bevy_simple_subsecond_system::reexports::bevy_ecs::world::World) #where_clause #original_output {
             use std::any::Any as _;
             let type_id = #hotpatched_fn #maybe_generics.type_id();
             let contains_system = world.get_resource::<::bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap().0.contains_key(&type_id);
             if !contains_system {
                 let hot_fn_ptr = #hot_fn.ptr_address();
-                let system_ptr_update_id = world.register_system(move |world: &mut ::bevy::ecs::world::World| {
+                let system_ptr_update_id = world.register_system(move |world: &mut ::bevy_simple_subsecond_system::reexports::bevy_ecs::world::World| {
                     let needs_update = {
                         let mut hot_patched_systems = world.get_resource_mut::<::bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap();
                         let mut hot_patched_system = hot_patched_systems.0.get_mut(&type_id).unwrap();

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -105,18 +105,18 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let hot_fn = quote! {
-        bevy_simple_subsecond_system::dioxus_devtools::subsecond::HotFn::current(#hotpatched_fn #maybe_generics)
+        ::bevy_simple_subsecond_system::dioxus_devtools::subsecond::HotFn::current(#hotpatched_fn #maybe_generics)
     };
 
     let maybe_run_call = if rerun_on_hot_patch {
         quote! {
-            let name = bevy::ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
-            bevy::prelude::debug!("Hot-patched and rerunning system {name}");
+            let name = ::bevy::ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
+            ::bevy::prelude::debug!("Hot-patched and rerunning system {name}");
             #hot_fn.call((world,))
         }
     } else {
         quote! {
-            let name = bevy::ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
+            let name = ::bevy::ecs::system::IntoSystem::into_system(#original_fn_name #maybe_generics).name();
             bevy::prelude::debug!("Hot-patched system {name}");
         }
     };
@@ -133,13 +133,13 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let hotpatched_fn_definition = match has_single_world_param(sig) {
         WorldParam::Mut | WorldParam::Ref => quote! {
-            #vis fn #hotpatched_fn #impl_generics(world: &mut bevy::ecs::world::World) #where_clause #original_output {
+            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy::ecs::world::World) #where_clause #original_output {
                 #original_wrapper_fn #maybe_generics(world)
             }
         },
         WorldParam::None => quote! {
-            #vis fn #hotpatched_fn #impl_generics(world: &mut bevy::ecs::world::World) #where_clause #original_output {
-                use bevy::ecs::system::SystemState;
+            #vis fn #hotpatched_fn #impl_generics(world: &mut ::bevy::ecs::world::World) #where_clause #original_output {
+                use ::bevy::ecs::system::SystemState;
                 let mut __system_state: SystemState<(#(#param_types),*)> = SystemState::new(world);
                 let __unsafe_world = world.as_unsafe_world_cell_readonly();
 
@@ -170,15 +170,15 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         // Outer entry point: stable ABI, hot-reload safe
         #[cfg(all(not(target_family = "wasm"), debug_assertions))]
-        #vis fn #original_fn_name #impl_generics(world: &mut bevy::ecs::world::World) #where_clause #original_output {
+        #vis fn #original_fn_name #impl_generics(world: &mut ::bevy::ecs::world::World) #where_clause #original_output {
             use std::any::Any as _;
             let type_id = #hotpatched_fn #maybe_generics.type_id();
-            let contains_system = world.get_resource::<bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap().0.contains_key(&type_id);
+            let contains_system = world.get_resource::<::bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap().0.contains_key(&type_id);
             if !contains_system {
                 let hot_fn_ptr = #hot_fn.ptr_address();
-                let system_ptr_update_id = world.register_system(move |world: &mut bevy::ecs::world::World| {
+                let system_ptr_update_id = world.register_system(move |world: &mut ::bevy::ecs::world::World| {
                     let needs_update = {
-                        let mut hot_patched_systems = world.get_resource_mut::<bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap();
+                        let mut hot_patched_systems = world.get_resource_mut::<::bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap();
                         let mut hot_patched_system = hot_patched_systems.0.get_mut(&type_id).unwrap();
                         hot_patched_system.current_ptr = #hot_fn.ptr_address();
                         let needs_update = hot_patched_system.current_ptr != hot_patched_system.last_ptr;
@@ -191,12 +191,12 @@ pub fn hot(attr: TokenStream, item: TokenStream) -> TokenStream {
                     // TODO: we simply ignore the `Result` here, but we should be propagating it
                     #maybe_run_call;
                 });
-                let system = bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystem {
+                let system = ::bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystem {
                     system_ptr_update_id,
                     current_ptr: hot_fn_ptr,
                     last_ptr: hot_fn_ptr,
                 };
-                world.get_resource_mut::<bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap().0.insert(type_id, system);
+                world.get_resource_mut::<::bevy_simple_subsecond_system::__macros_internal::__HotPatchedSystems>().unwrap().0.insert(type_id, system);
             }
 
             #hot_fn.call((world,))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,6 @@ pub use dioxus_devtools;
 #[cfg(all(not(target_family = "wasm"), debug_assertions))]
 use dioxus_devtools::{subsecond::apply_patch, *};
 
-/// Reexports of bevy crates for macro usage
-pub mod reexports {
-    pub use bevy_ecs;
-    pub use bevy_log;
-}
-
 /// Everything you need to use hotpatching
 pub mod prelude {
     pub use super::{HotPatched, SimpleSubsecondPlugin};
@@ -100,8 +94,12 @@ fn update_system_ptr(hot_patched_systems: Res<HotPatchedSystems>, mut commands: 
 }
 #[doc(hidden)]
 pub mod __macros_internal {
-    use bevy_ecs::system::SystemId;
-    use bevy_ecs_macros::Resource;
+    pub use bevy_ecs::{
+        system::{IntoSystem, SystemId, SystemState},
+        world::World,
+    };
+    pub use bevy_ecs_macros::Resource;
+    pub use bevy_log::debug;
     use bevy_platform::collections::HashMap;
     use std::any::TypeId;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,23 @@
 
 #[cfg(all(not(target_family = "wasm"), debug_assertions))]
 use __macros_internal::__HotPatchedSystems as HotPatchedSystems;
-use bevy::prelude::*;
+use bevy_app::{App, Plugin, PreUpdate};
+#[cfg(all(not(target_family = "wasm"), debug_assertions))]
+use bevy_ecs::system::{Commands, Res};
+use bevy_ecs::{
+    event::{Event, EventWriter},
+    schedule::IntoScheduleConfigs,
+};
 pub use bevy_simple_subsecond_system_macros::*;
 pub use dioxus_devtools;
 #[cfg(all(not(target_family = "wasm"), debug_assertions))]
 use dioxus_devtools::{subsecond::apply_patch, *};
+
+/// Reexports of bevy crates for macro usage
+pub mod reexports {
+    pub use bevy_ecs;
+    pub use bevy_log;
+}
 
 /// Everything you need to use hotpatching
 pub mod prelude {
@@ -88,9 +100,10 @@ fn update_system_ptr(hot_patched_systems: Res<HotPatchedSystems>, mut commands: 
 }
 #[doc(hidden)]
 pub mod __macros_internal {
+    use bevy_ecs::system::SystemId;
+    use bevy_ecs_macros::Resource;
+    use bevy_platform::collections::HashMap;
     use std::any::TypeId;
-
-    use bevy::{ecs::system::SystemId, platform::collections::HashMap, prelude::*};
 
     #[derive(Resource, Default)]
     pub struct __HotPatchedSystems(pub HashMap<TypeId, __HotPatchedSystem>);


### PR DESCRIPTION
Using absolute paths for external crate types prevents possible name collisions.

i.e., in someone's code that loves gltf

```rust
//why? idk
use bevy_gltf as bevy;

// macro panics
#[hot]
fn munch_gltf(gltf: bevy::Gltf) {...}
```